### PR TITLE
Support multiple containers per pod

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,34 @@ git clone git@github.com:brosandilabs/kubectl-tmux-logs.git ~/.kube/plugins/kube
 ```
 
 ### Usage
-Get logs from all pods in the "my-namespace" namespace:
+
+```
+> kubectl plugin tmux-logs --help
+tmux-logs integrates kubectl logs with tmux by opening a new pane for each pod-container log
+
+Options:
+  -c, --container='': Container name (for pods with multiple containers)
+  -l, --selector='': Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
+
+Usage:
+  kubectl plugin tmux-logs [flags] [options]
+
+Use "kubectl options" for a list of global command-line options (applies to all commands).
+
+```
+
+### Examples
+Get logs from all containers in the "my-namespace" namespace:
 ```
 kubectl plugin tmux-logs -n my-namespace
 ```
 
-Get logs from pods matching the "name=my-pod" selector in the "my-namespace" namespace:
+Get logs from all containers in pods matching the "name=my-pod" selector in the "my-namespace" namespace:
 ```
 kubectl plugin tmux-logs -l name=my-pod -n my-namespace
+```
+
+Get logs from a specific container in pods with "app=my-app" label:
+```
+kubectl plugin tmux-logs -l app=my-app -c some-container-name
 ```

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,8 +1,11 @@
 name: "tmux-logs"
 shortDesc: "tmux integration for kubectl logs"
-longDesc: "tmux-logs integrates kubectl logs with tmux by opening a new pane for each pod log"
+longDesc: "tmux-logs integrates kubectl logs with tmux by opening a new pane for each pod-container log"
 command: "./tmux-logs"
 flags:
   - name: "selector"
     shorthand: "l"
     desc: "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)"
+  - name: "container"
+    shorthand: "c"
+    desc: "Container name (for pods with multiple containers)"

--- a/tmux-logs
+++ b/tmux-logs
@@ -1,8 +1,9 @@
 #!/bin/sh
 
 TMUX_SESSION_NAME=$(tmux display-message -p "#S")
-SELECTOR=$KUBECTL_PLUGINS_LOCAL_FLAG_SELECTOR
 NAMESPACE=$KUBECTL_PLUGINS_CURRENT_NAMESPACE
+SELECTOR=$KUBECTL_PLUGINS_LOCAL_FLAG_SELECTOR
+CONTAINER=$KUBECTL_PLUGINS_LOCAL_FLAG_CONTAINER
 
 # creates a new tmux window
 createNewTmuxWindow() {
@@ -25,12 +26,18 @@ ensureTmuxSessionExists() {
     fi
 }
 
-# gets pod names from a name selector
-getPods() {
-    if [ -z "${SELECTOR}" ]; then
-        kubectl get pods -n ${NAMESPACE} -o name --no-headers
+# gets pod and container names from a name selector
+getPodContainers() {
+    if [ -z "${CONTAINER}" ]; then
+        GO_TEMPLATE="{{range .items}}{{\$name:=.metadata.name}}{{range .spec.containers}}{{print \$name}}_{{.name}} {{end}}{{end}}"
     else
-        kubectl get pods -l "${SELECTOR}" -n ${NAMESPACE} -o name --no-headers
+        GO_TEMPLATE="{{range .items}}{{\$name:=.metadata.name}}{{range .spec.containers}}{{if eq .name \"${CONTAINER}\"}}{{print \$name}}_{{.name}} {{end}}{{end}}{{end}}"
+    fi
+
+    if [ -z "${SELECTOR}" ]; then
+        kubectl get pods -n ${NAMESPACE} -o go-template --template="${GO_TEMPLATE}"
+    else
+        kubectl get pods -n ${NAMESPACE} -l "${SELECTOR}" -o go-template --template="${GO_TEMPLATE}"
     fi
 }
 
@@ -57,10 +64,11 @@ unsynchronizePanes() {
 tailContainerLogs() {
     INDEX=0
 
-    PODS=$(getPods)
+    POD_CONTAINERS=$(getPodContainers)
 
-    for POD in ${PODS}; do
-        KUBECTL_LOGS_COMMAND="kubectl logs -f ${POD} -n ${NAMESPACE}"
+    for POD_CONTAINER in ${POD_CONTAINERS}; do
+        POD_CONTAINER_SPACED="${POD_CONTAINER/_/ }"
+        KUBECTL_LOGS_COMMAND="kubectl -n ${NAMESPACE} logs -f ${POD_CONTAINER_SPACED}"
         if [ ${INDEX} -eq 0 ]; then
             createNewTmuxWindow "${KUBECTL_LOGS_COMMAND}"
         else


### PR DESCRIPTION
Currently, the plugin fails when pods have multiple containers (kubectl requires you to specify the pod name).  
This PR lets you filter for a specific pod or default to track all containers in the selected pods.